### PR TITLE
HH-31 UI для отображения ошибки

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/common/ErrorStateView.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/common/ErrorStateView.kt
@@ -1,0 +1,48 @@
+package ru.practicum.android.diploma.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.withStyledAttributes
+import ru.practicum.android.diploma.R
+
+class ErrorStateView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val errorImage: ImageView
+    private val errorText: TextView
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.view_error_state, this, true)
+        errorImage = findViewById(R.id.error_image)
+        errorText  = findViewById(R.id.error_text)
+        context.withStyledAttributes(attrs, R.styleable.ErrorStateView) {
+            val imgRes = getResourceId(
+                R.styleable.ErrorStateView_errorImage,
+                R.drawable.image_error_no_internet
+            )
+            errorImage.setImageResource(imgRes)
+            getString(R.styleable.ErrorStateView_errorText)
+                ?.let { errorText.text = it }
+            val txtColor = getColor(
+                R.styleable.ErrorStateView_errorTextColor,
+                errorText.currentTextColor
+            )
+            errorText.setTextColor(txtColor)
+        }
+    }
+
+    fun setErrorImage(resId: Int) {
+        errorImage.setImageResource(resId)
+    }
+
+    fun setErrorText(text: String) {
+        errorText.text = text
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/ui/common/ErrorStateView.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/common/ErrorStateView.kt
@@ -19,9 +19,11 @@ class ErrorStateView @JvmOverloads constructor(
     private val errorText: TextView
 
     init {
-        LayoutInflater.from(context).inflate(R.layout.view_error_state, this, true)
+        LayoutInflater.from(context)
+            .inflate(R.layout.view_error_state, this, true)
+
         errorImage = findViewById(R.id.error_image)
-        errorText  = findViewById(R.id.error_text)
+        errorText = findViewById(R.id.error_text)
         context.withStyledAttributes(attrs, R.styleable.ErrorStateView) {
             val imgRes = getResourceId(
                 R.styleable.ErrorStateView_errorImage,

--- a/app/src/main/res/layout/view_error_state.xml
+++ b/app/src/main/res/layout/view_error_state.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <LinearLayout
+        android:id="@+id/error_root"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="@dimen/padding16">
+
+        <ImageView
+            android:id="@+id/error_image"
+            android:layout_width="@dimen/error_image_width"
+            android:layout_height="@dimen/error_image_height"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:contentDescription="@null"
+            android:src="@drawable/image_error_no_internet" />
+
+        <TextView
+            android:id="@+id/error_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding16"
+            android:fontFamily="@font/ys_display_medium"
+            android:textSize="22sp"
+            android:textColor="?attr/textColorPrimary"
+            android:text="@string/search_vacancies_no_internet"/>
+
+    </LinearLayout>
+
+</merge>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -10,4 +10,9 @@
         <attr name="searchHintColor" format="color"/>
         <attr name="searchHint" format="string"/>
     </declare-styleable>
+    <declare-styleable name="ErrorStateView">
+        <attr name="errorImage"     format="reference"/>
+        <attr name="errorText"      format="string"/>
+        <attr name="errorTextColor" format="reference|color"/>
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,4 +13,7 @@
     <dimen name="toolbar_height">64dp</dimen>
 
     <dimen name="search_bar_height">56dp</dimen>
+
+    <dimen name="error_image_width">328dp</dimen>
+    <dimen name="error_image_height">223dp</dimen>
 </resources>


### PR DESCRIPTION
Как я это понял и сделал: 
- класс ErrorStateView подготавливает UI для отображения ошибки
- в XML добавить id 
- В коде фрагмента можно вписать так 
binding.errorStateView.isVisible = true
binding.errorStateView.setErrorImage(R.drawable.image_error_vacancy_404)
binding.errorStateView.setErrorText(getString(R.string.search_vacancies_placeholder_not_found))
и должно работать) 